### PR TITLE
Update to be compatible with new FuzzBench version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ See our paper [FIXREVERTER: A Realistic Bug Injection Methodology for Benchmarki
 This repository consists of 5 directories, and each of them will be introduced in the following sections.
 
 ## fuzzbench
-**RevBugBench** was developed on FuzzBench commit 65297c4c76e63cbe4025f1ce7abc1e89b7a1566c. 
+**RevBugBench** currently supports FuzzBench commit 7c70037a73d2cc66627c6109d53d20b3594f85c9. 
 The [diff file](/fuzzbench/revbugbench.patch) shows the modifications made by RevBugBench. 
-The following commands on will apply the changes.
+The following commands will apply the changes.
 ```
 cd [path/to/fuzzbench]
 git checkout 65297c4c76e63cbe4025f1ce7abc1e89b7a1566c

--- a/benchmarks/binutils-fuzz_cxxfilt/Dockerfile
+++ b/benchmarks/binutils-fuzz_cxxfilt/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && apt-get install -y make autoconf autogen texinfo flex bison
 

--- a/benchmarks/binutils-fuzz_cxxfilt/build.sh
+++ b/benchmarks/binutils-fuzz_cxxfilt/build.sh
@@ -1,14 +1,16 @@
-/* Copyright 2020 Google Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+#!/bin/bash -eu
+
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
 cd binutils-gdb
 git apply ../fr_injection.patch
@@ -21,7 +23,7 @@ cd ../
 ./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
 	    --disable-libdecnumber --disable-readline --disable-sim \
 	    --enable-targets=all --disable-werror
-make -j4
+make -j
 
 cd binutils
 cp ../../fuzz_cxxfilt.c .

--- a/benchmarks/binutils-fuzz_disassemble/Dockerfile
+++ b/benchmarks/binutils-fuzz_disassemble/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && apt-get install -y make autoconf autogen texinfo flex bison
 

--- a/benchmarks/binutils-fuzz_disassemble/build.sh
+++ b/benchmarks/binutils-fuzz_disassemble/build.sh
@@ -1,14 +1,16 @@
-/* Copyright 2020 Google Inc.
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-      http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
+#!/bin/bash -eu
+
+# Copyright 2020 Google Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#       http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
 cd binutils-gdb
 git apply ../fr_injection.patch
@@ -21,7 +23,7 @@ cd ../
 ./configure --disable-gdb --disable-gdbserver --disable-gdbsupport \
 	    --disable-libdecnumber --disable-readline --disable-sim \
 	    --enable-targets=all --disable-werror
-make -j4
+make -j
 
 mkdir -p fuzz
 cp ../fuzz_*.c fuzz/

--- a/benchmarks/curl/Dockerfile
+++ b/benchmarks/curl/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 # Curl will be checked out to the commit hash specified in benchmark.yaml.
 RUN git clone https://github.com/curl/curl.git $SRC/curl && git -C $SRC/curl checkout -f 376d5bb323c03c0fc4af266c03abac8f067fbd0e

--- a/benchmarks/lcms/Dockerfile
+++ b/benchmarks/lcms/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/libpcap/Dockerfile
+++ b/benchmarks/libpcap/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 RUN apt-get update && apt-get install -y make cmake flex bison
 
 RUN git clone https://github.com/the-tcpdump-group/libpcap.git $SRC/libpcap && git -C $SRC/libpcap checkout -f d615abec7e0237299250c409dca23effb8dd36cc

--- a/benchmarks/libxml2_reader/Dockerfile
+++ b/benchmarks/libxml2_reader/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 ENV GIT_SSL_NO_VERIFY 1
 

--- a/benchmarks/libxml2_xml/Dockerfile
+++ b/benchmarks/libxml2_xml/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 ENV GIT_SSL_NO_VERIFY 1
 

--- a/benchmarks/proj4/Dockerfile
+++ b/benchmarks/proj4/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && \
     apt-get install -y \

--- a/benchmarks/usrsctp/Dockerfile
+++ b/benchmarks/usrsctp/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 RUN apt-get update && apt-get install -y make cmake pkg-config
 
 RUN git clone https://github.com/weinrank/usrsctp $SRC/usrsctp && git -C $SRC/usrsctp checkout -f e08eacffd438cb0760c926fbe60ccda011f6ce70

--- a/benchmarks/usrsctp/build.sh
+++ b/benchmarks/usrsctp/build.sh
@@ -18,9 +18,9 @@
 git apply ../fr_injection.patch
 # add FRCOV flag if building coverage
 if [[ -z "${FR_COV_BUILD}" ]]; then
-  cmake -Dsctp_build_programs=0 -Dsctp_debug=0 -Dsctp_invariants=1 -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+  cmake -Dsctp_build_programs=0 -Dsctp_debug=0 -Dsctp_invariants=1 -DCMAKE_C_FLAGS="-Wno-error=unused-but-set-variable" -DCMAKE_CXX_FLAGS="-Wno-error=unused-but-set-variable" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 else
-  cmake -Dsctp_build_programs=0 -Dsctp_debug=0 -Dsctp_invariants=1 -DCMAKE_C_FLAGS=-DFRCOV -DCMAKE_CXX_FLAGS=-DFRCOV -DCMAKE_BUILD_TYPE=RelWithDebInfo .
+  cmake -Dsctp_build_programs=0 -Dsctp_debug=0 -Dsctp_invariants=1 -DCMAKE_C_FLAGS="-DFRCOV -Wno-error=unused-but-set-variable" -DCMAKE_CXX_FLAGS="-DFRCOV -Wno-error=unused-but-set-variable" -DCMAKE_BUILD_TYPE=RelWithDebInfo .
 fi
 
 make

--- a/benchmarks/zstd/Dockerfile
+++ b/benchmarks/zstd/Dockerfile
@@ -14,7 +14,7 @@
 #
 ################################################################################
 
-FROM gcr.io/oss-fuzz-base/base-builder@sha256:b112cfb8b4adbb796643f42f8ba40b92962912893f64d617b2706d51c1bd1a53
+FROM gcr.io/oss-fuzz-base/base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
 
 RUN apt-get update && apt-get install -y make python wget
 # Clone source

--- a/fuzzbench/revbugbench.patch
+++ b/fuzzbench/revbugbench.patch
@@ -1,30 +1,5 @@
-diff --git a/experiment/build/builder.py b/experiment/build/builder.py
-index 706992c..a0ec5c9 100644
---- a/experiment/build/builder.py
-+++ b/experiment/build/builder.py
-@@ -40,7 +40,7 @@ else:
- # FIXME: Use 10 as default quota.
- # Even though it says queueing happen, we end up exceeding limits on "get", so
- # be conservative. Use 30 for now since this is limit for FuzzBench service.
--DEFAULT_MAX_CONCURRENT_BUILDS = 30
-+DEFAULT_MAX_CONCURRENT_BUILDS = 5
- 
- # Build fail retries and wait interval.
- NUM_BUILD_RETRIES = 3
-diff --git a/experiment/build/local_build.py b/experiment/build/local_build.py
-index 1f6fd38..282caa8 100644
---- a/experiment/build/local_build.py
-+++ b/experiment/build/local_build.py
-@@ -32,7 +32,6 @@ def make(targets):
-     command = ['make', '-j'] + targets
-     return new_process.execute(command, cwd=utils.ROOT_DIR)
- 
--
- def build_base_images() -> Tuple[int, str]:
-     """Build base images locally."""
-     return make(['base-image', 'worker'])
 diff --git a/experiment/measurer/run_coverage.py b/experiment/measurer/run_coverage.py
-index 4f83d8a..f7419e7 100644
+index 05fb2a1c..2f5ec67b 100644
 --- a/experiment/measurer/run_coverage.py
 +++ b/experiment/measurer/run_coverage.py
 @@ -32,10 +32,10 @@ EXIT_BUFFER = 15
@@ -39,22 +14,9 @@ index 4f83d8a..f7419e7 100644
 +MAX_TOTAL_TIME = 90
  
  
- def find_crashing_units(artifacts_dir: str) -> List[str]:
-diff --git a/experiment/resources/runner-startup-script-template.sh b/experiment/resources/runner-startup-script-template.sh
-index 00945fd..8fa18a6 100644
---- a/experiment/resources/runner-startup-script-template.sh
-+++ b/experiment/resources/runner-startup-script-template.sh
-@@ -35,7 +35,7 @@ do
- done{% endif %}
- 
- docker run \
----privileged --cpus={{num_cpu_cores}} --rm \
-+--privileged --cpus={{num_cpu_cores}} \
- -e INSTANCE_NAME={{instance_name}} \
- -e FUZZER={{fuzzer}} \
- -e BENCHMARK={{benchmark}} \
+ def do_coverage_run(  # pylint: disable=too-many-locals
 diff --git a/fuzzers/coverage/fuzzer.py b/fuzzers/coverage/fuzzer.py
-index bb2fad3..f6cd1e7 100644
+index bb2fad34..f6cd1e77 100644
 --- a/fuzzers/coverage/fuzzer.py
 +++ b/fuzzers/coverage/fuzzer.py
 @@ -21,7 +21,7 @@ from fuzzers import utils


### PR DESCRIPTION
- Updated benchmarks to use base-builder@sha256:87ca1e9e19235e731fac8de8d1892ebe8d55caf18e7aa131346fc582a2034fdd
- Updated RevBugBench/fuzzbench/revbugbench.patch for FuzzBench version 7c70037a73d2cc66627c6109d53d20b3594f85c9
- Updated RevBugBench/benchmarks/usrsctp/build.sh to address building errors
- Updated RevBugBench/benchmarks/binutils-cxxfilt/build.sh to address building errors
- Updated RevBugBench/benchmarks/binutils-disassemble/build.sh to address building errors
- Updated RevBugBench/README.md